### PR TITLE
feat: recognise .kts as Kotlin files

### DIFF
--- a/languages/kotlin/config.toml
+++ b/languages/kotlin/config.toml
@@ -1,6 +1,6 @@
 name = "Kotlin"
 grammar = "kotlin"
-path_suffixes = ["kt"]
+path_suffixes = ["kt", "kts"]
 line_comments = ["// "]
 brackets = [
     { start = "(", end = ")", close = true, newline = false },


### PR DESCRIPTION
This PR enables Kotlin syntax highlight for .kts files which - for my understanding - uses the same language but are meant for scripting purposes.

A clear use case are various `*.gradle.kts` in Gradle projects.