### PR TITLE
Update language server ID to `kotlin-language-server`

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -6,7 +6,7 @@ authors = ["evrsen", "cholwell"]
 description = "Kotlin language support."
 repository = "https://github.com/zed-extensions/kotlin"
 
-[language_servers.kotlin]
+[language_servers.kotlin-language-server]
 name = "Kotlin Language Server"
 language = "Kotlin"
 


### PR DESCRIPTION
This PR updates the language server ID from `kotlin` to `kotlin-language-server`.