### PR TITLE
Make the language server binary executable after download

### DIFF
--- a/src/kotlin.rs
+++ b/src/kotlin.rs
@@ -59,6 +59,9 @@ impl KotlinExtension {
                 zed::DownloadedFileType::Zip,
             )
             .map_err(|e| format!("failed to download file error: {e}"))?;
+
+            zed::make_file_executable(&binary_path)
+                .map_err(|e| format!("failed to make binary executable: {e}"))?;
         }
 
         self.cached_binary_path = Some(binary_path.clone());


### PR DESCRIPTION
Resolves #19
Draft because I'm unsure this repo is the correct place to fix the issue. Maybe it should be `zed::download_file`'s job to carry over file permissions when extracting a zip file.

Note that `zed::make_file_executable` is a noop on non-unix platforms, so it shouldn't be an issue to call it here.