### PR TITLE
Refactor structure, add downloading states to Kotlin LSP

### DIFF
--- a/src/language_servers/kotlin_language_server.rs
+++ b/src/language_servers/kotlin_language_server.rs
@@ -2,54 +2,76 @@ use std::fs;
 
 use zed_extension_api::{self as zed, Result};
 
-pub const LANGUAGE_SERVER_ID: &'static str = "kotlin-language-server";
+pub struct KotlinLanguageServer {
+    cached_binary_path: Option<String>,
+}
 
-pub fn language_server_binary_path(language_server_id: &zed::LanguageServerId) -> Result<String> {
-    zed::set_language_server_installation_status(
-        language_server_id,
-        &zed::LanguageServerInstallationStatus::CheckingForUpdate,
-    );
-    let release = zed::latest_github_release(
-        "fwcd/kotlin-language-server",
-        zed::GithubReleaseOptions {
-            require_assets: true,
-            pre_release: false,
-        },
-    )?;
+impl KotlinLanguageServer {
+    pub const LANGUAGE_SERVER_ID: &'static str = "kotlin-language-server";
 
-    let asset_name = "server.zip";
-    let asset = release
-        .assets
-        .iter()
-        .find(|asset| asset.name == asset_name)
-        .ok_or_else(|| "no asset found")?;
-
-    let (os, _arch) = zed::current_platform();
-    let version_dir = format!("kotlin-language-server-{}", release.version);
-    let binary_path = format!(
-        "{version_dir}/server/bin/kotlin-language-server{extension}",
-        extension = match os {
-            zed::Os::Mac | zed::Os::Linux => "",
-            zed::Os::Windows => ".bat",
+    pub fn new() -> Self {
+        Self {
+            cached_binary_path: None,
         }
-    );
+    }
+}
 
-    if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+impl KotlinLanguageServer {
+    pub fn language_server_binary_path(
+        &mut self,
+        language_server_id: &zed::LanguageServerId,
+    ) -> Result<String> {
+        if let Some(path) = self.cached_binary_path.as_ref() {
+            return Ok(path.clone());
+        }
+
         zed::set_language_server_installation_status(
-            &language_server_id,
-            &zed::LanguageServerInstallationStatus::Downloading,
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+        );
+        let release = zed::latest_github_release(
+            "fwcd/kotlin-language-server",
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        )?;
+
+        let asset_name = "server.zip";
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| "no asset found")?;
+
+        let (os, _arch) = zed::current_platform();
+        let version_dir = format!("kotlin-language-server-{}", release.version);
+        let binary_path = format!(
+            "{version_dir}/server/bin/kotlin-language-server{extension}",
+            extension = match os {
+                zed::Os::Mac | zed::Os::Linux => "",
+                zed::Os::Windows => ".bat",
+            }
         );
 
-        zed::download_file(
-            &asset.download_url,
-            &version_dir,
-            zed::DownloadedFileType::Zip,
-        )
-        .map_err(|e| format!("failed to download file error: {e}"))?;
+        if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+            zed::set_language_server_installation_status(
+                &language_server_id,
+                &zed::LanguageServerInstallationStatus::Downloading,
+            );
 
-        zed::make_file_executable(&binary_path)
-            .map_err(|e| format!("failed to make binary executable: {e}"))?;
+            zed::download_file(
+                &asset.download_url,
+                &version_dir,
+                zed::DownloadedFileType::Zip,
+            )
+            .map_err(|e| format!("failed to download file error: {e}"))?;
+
+            zed::make_file_executable(&binary_path)
+                .map_err(|e| format!("failed to make binary executable: {e}"))?;
+        }
+
+        self.cached_binary_path = Some(binary_path.clone());
+        Ok(binary_path)
     }
-
-    return Ok(binary_path);
 }

--- a/src/language_servers/mod.rs
+++ b/src/language_servers/mod.rs
@@ -1,2 +1,5 @@
-pub mod kotlin_language_server;
-pub mod kotlin_lsp;
+mod kotlin_language_server;
+mod kotlin_lsp;
+
+pub use kotlin_language_server::KotlinLanguageServer;
+pub use kotlin_lsp::KotlinLSP;


### PR DESCRIPTION
This PR aligns this extensions structure more with how we generally implement it for other extensions and also ensures that we show downloading states for the Kotlin LSP download.